### PR TITLE
pyproject: set ruff.lint.pyugrade.keep-runtime-typing to true

### DIFF
--- a/environment_helpers/introspect.py
+++ b/environment_helpers/introspect.py
@@ -124,7 +124,7 @@ class Introspectable:
         args_dict = {'args': args, 'kwargs': kwargs}
         pickled_args_dict = pickle.dumps(args_dict)
 
-        script = pathlib.Path(__file__).parent / '_scripts' / f'call.py'
+        script = pathlib.Path(__file__).parent / '_scripts' / 'call.py'
         data = subprocess.check_output(
             [os.fspath(self._interpreter), os.fspath(script), module, func_name],
             input=pickled_args_dict,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ extend-select = [
   'RUF',  # ruff
 ]
 
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = true
+
 [tool.ruff.lint.mccabe]
 max-complexity = 10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,4 @@ max-complexity = 10
 [tool.ruff.lint.isort]
 lines-between-types = 1
 lines-after-imports = 2
+known-first-party = ['environment_helpers']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def example_wheel(packages_path, tmp_path_factory):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def venv(tmp_path):
     return environment_helpers.create_venv(tmp_path)
 

--- a/tests/helpers/introspect.py
+++ b/tests/helpers/introspect.py
@@ -16,13 +16,16 @@ import environment_helpers.introspect  # noqa: E402
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('action', choices=[
-        'get_virtual_environment_scheme',
-        'get_version',
-        'get_scheme',
-        'get_system_scheme',
-        'get_launcher_kind',
-    ])
+    parser.add_argument(
+        'action',
+        choices=[
+            'get_virtual_environment_scheme',
+            'get_version',
+            'get_scheme',
+            'get_system_scheme',
+            'get_launcher_kind',
+        ],
+    )
     parser.add_argument('--interpreter', type=str, default=sys.executable)
     parser.add_argument('--write-to-file', type=pathlib.Path, required=False)
     args = parser.parse_args()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -32,4 +32,3 @@ def build_wheel_via_sdist_fail(packages_path, tmp_path):
     package = packages_path / 'test-cant-build-via-sdist'
     with pytest.raises(build.BuildBackendException):
         environment_helpers.build.build_wheel_via_sdist(package, tmp_path)
-


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>